### PR TITLE
Implement nexus health and GameOver state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub enum GameState {
     #[default]
     MainMenu,
     InGame,
+    GameOver, // Added GameOver state
 }
 
 fn main() {
@@ -16,6 +17,7 @@ fn main() {
             primary_window: Some(Window {
                 title: "Chroma Maze".into(),
                 resolution: (1000.0, 800.0).into(),
+                present_mode: bevy::window::PresentMode::AutoNoVsync, // Try to disable vsync for headless
                 ..default()
             }),
             ..default()
@@ -27,8 +29,12 @@ fn main() {
             // Simple state transition for starting the game
             |mut next_state: ResMut<NextState<GameState>>| {
                 next_state.set(GameState::InGame);
+                println!("Switched to InGame state");
             }
         ))
+        .add_systems(OnEnter(GameState::GameOver), || {
+            println!("Entered GameOver state!");
+        })
         .add_plugins(game::GamePlugin)
         .run();
 }


### PR DESCRIPTION
- Enemies now damage the nexus upon reaching it.
- Nexus health is tracked in the `Nexus` component.
- Added a `GameOver` state to `GameState`.
- Implemented `check_nexus_health_system` to transition to `GameOver` when nexus health reaches zero.
- Registered the new system in `GamePlugin`.
- Added debug prints for state transitions.