### PR TITLE
Add tower placement via mouse input

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -1,8 +1,12 @@
+use bevy::input::{
+    mouse::{MouseButton, MouseButtonInput},
+    ButtonState,
+};
 use bevy::prelude::*;
 use bevy_prototype_lyon::prelude::*;
-use petgraph::graph::{NodeIndex, UnGraph};
 #[allow(unused_imports)] // We will use astar later
 use petgraph::algo::astar;
+use petgraph::graph::{NodeIndex, UnGraph};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 // Import the new color palettes
@@ -24,16 +28,23 @@ pub struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app
-            .add_plugins(ShapePlugin)
-            .insert_resource(EnemySpawnTimer(Timer::from_seconds(2.0, TimerMode::Repeating)))
+        app.add_plugins(ShapePlugin)
+            .insert_resource(EnemySpawnTimer(Timer::from_seconds(
+                2.0,
+                TimerMode::Repeating,
+            )))
             .add_systems(OnEnter(GameState::InGame), setup_game)
-            .add_systems(Update, (
-                tower_targeting_system,
-                spawn_enemies_system,
-                move_enemies_system,
-                check_nexus_health_system, // Added the new system here
-            ).run_if(in_state(GameState::InGame)));
+            .add_systems(
+                Update,
+                (
+                    tower_targeting_system,
+                    tower_placement_system,
+                    spawn_enemies_system,
+                    move_enemies_system,
+                    check_nexus_health_system, // Added the new system here
+                )
+                    .run_if(in_state(GameState::InGame)),
+            );
     }
 }
 
@@ -107,7 +118,7 @@ fn setup_game(mut commands: Commands) {
                 (y as f32 - maze.height as f32 / 2.0) * TILE_SIZE,
                 0.0,
             );
-            
+
             let color = match tile_type {
                 TileType::Wall => css::DARK_GRAY.into(),
                 TileType::Floor => css::BLACK.into(),
@@ -152,7 +163,7 @@ fn setup_game(mut commands: Commands) {
         Stroke::new(css::WHITE, 2.0),
         Nexus { health: 100.0 },
     ));
-    
+
     commands.insert_resource(maze);
 
     // Spawn a test tower
@@ -163,7 +174,8 @@ fn setup_game(mut commands: Commands) {
             range: 150.0, // Adjusted for TILE_SIZE units
             target: None,
         },
-        ShapeBundle { // Using ShapeBundle for a simple visual representation
+        ShapeBundle {
+            // Using ShapeBundle for a simple visual representation
             path: GeometryBuilder::build_as(&shapes::RegularPolygon {
                 sides: 3, // Triangle
                 feature: shapes::RegularPolygonFeature::Radius(TILE_SIZE * 0.6),
@@ -180,7 +192,7 @@ fn setup_game(mut commands: Commands) {
         Stroke::new(css::BLACK, 1.0),
     ));
     println!("Spawned a test tower at (0,0)");
-    
+
     println!("Game setup complete. Maze generated.");
 }
 
@@ -198,13 +210,19 @@ fn tower_targeting_system(
                 if tower_position.distance(target_position) > tower.range {
                     // Target out of range
                     tower.target = None;
-                    println!("Tower {:?} lost target {:?} (out of range)", _tower_entity, target_entity);
+                    println!(
+                        "Tower {:?} lost target {:?} (out of range)",
+                        _tower_entity, target_entity
+                    );
                 }
                 // Else, target is still valid and in range, do nothing
             } else {
                 // Target no longer exists (e.g., despawned)
                 tower.target = None;
-                println!("Tower {:?} lost target {:?} (despawned)", _tower_entity, target_entity);
+                println!(
+                    "Tower {:?} lost target {:?} (despawned)",
+                    _tower_entity, target_entity
+                );
             }
         }
 
@@ -214,8 +232,73 @@ fn tower_targeting_system(
                 let enemy_position = enemy_transform.translation();
                 if tower_position.distance(enemy_position) <= tower.range {
                     tower.target = Some(enemy_entity);
-                    println!("Tower {:?} acquired new target: {:?}", _tower_entity, enemy_entity);
+                    println!(
+                        "Tower {:?} acquired new target: {:?}",
+                        _tower_entity, enemy_entity
+                    );
                     break; // Target the first enemy in range
+                }
+            }
+        }
+    }
+}
+
+fn tower_placement_system(
+    mut commands: Commands,
+    mut mouse_events: EventReader<MouseButtonInput>,
+    windows: Query<&Window>,
+    camera_query: Query<(&Camera, &GlobalTransform)>,
+    maze: Res<Maze>,
+) {
+    let (camera, camera_transform) = match camera_query.get_single() {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let window = match windows.get_single() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    let Some(cursor_pos) = window.cursor_position() else {
+        return;
+    };
+    let Some(world_pos) = camera.viewport_to_world_2d(camera_transform, cursor_pos) else {
+        return;
+    };
+
+    for ev in mouse_events.read() {
+        if ev.state == ButtonState::Pressed && ev.button == MouseButton::Left {
+            let x = (world_pos.x / TILE_SIZE + maze.width as f32 / 2.0).floor() as isize;
+            let y = (world_pos.y / TILE_SIZE + maze.height as f32 / 2.0).floor() as isize;
+            if x >= 0 && x < maze.width as isize && y >= 0 && y < maze.height as isize {
+                let idx = y as usize * maze.width + x as usize;
+                if maze.tiles[idx] == TileType::Wall {
+                    let world_translation = Vec3::new(
+                        (x as f32 - maze.width as f32 / 2.0) * TILE_SIZE,
+                        (y as f32 - maze.height as f32 / 2.0) * TILE_SIZE,
+                        1.0,
+                    );
+                    commands.spawn((
+                        Tower {
+                            fire_rate: 1.0,
+                            range: 150.0,
+                            target: None,
+                        },
+                        ShapeBundle {
+                            path: GeometryBuilder::build_as(&shapes::RegularPolygon {
+                                sides: 3,
+                                feature: shapes::RegularPolygonFeature::Radius(TILE_SIZE * 0.6),
+                                ..shapes::RegularPolygon::default()
+                            }),
+                            spatial: SpatialBundle {
+                                transform: Transform::from_translation(world_translation),
+                                ..default()
+                            },
+                            mesh: default(),
+                            material: default(),
+                        },
+                        Fill::color(css::YELLOW),
+                        Stroke::new(css::BLACK, 1.0),
+                    ));
                 }
             }
         }
@@ -250,7 +333,7 @@ fn spawn_enemies_system(
                     },
                     transform: Transform::from_translation(start_pos_world),
                     ..default()
-                }
+                },
             ));
             println!("Spawned an enemy!");
         }
@@ -260,7 +343,7 @@ fn spawn_enemies_system(
 fn move_enemies_system(
     mut commands: Commands,
     mut enemy_query: Query<(Entity, &mut Transform, &mut Enemy)>, // Added Entity
-    mut nexus_query: Query<&mut Nexus>, // Query for Nexus
+    mut nexus_query: Query<&mut Nexus>,                           // Query for Nexus
     time: Res<Time>,
     maze: Res<Maze>,
 ) {
@@ -288,7 +371,6 @@ fn move_enemies_system(
         }
     }
 }
-
 
 // --- Maze Generation Logic ---
 fn generate_maze(width: usize, height: usize) -> Maze {
@@ -326,12 +408,12 @@ fn generate_maze(width: usize, height: usize) -> Maze {
             let wall_y = (cy + ny) / 2;
             tiles[wall_y * width + wall_x] = TileType::Floor;
             tiles[n_idx] = TileType::Floor;
-            
+
             visited[n_idx] = true;
             stack.push((nx, ny));
         }
     }
-    
+
     let mut graph = UnGraph::new_undirected();
     let mut node_map = vec![NodeIndex::end(); width * height];
 
@@ -363,11 +445,19 @@ fn generate_maze(width: usize, height: usize) -> Maze {
     let entrance = (1, 1);
     let nexus_pos = (width / 2, height / 2);
     if tiles[nexus_pos.1 * width + nexus_pos.0] == TileType::Wall {
-       tiles[nexus_pos.1 * width + nexus_pos.0] = TileType::Floor;
+        tiles[nexus_pos.1 * width + nexus_pos.0] = TileType::Floor;
     }
 
     // Now we return the node_map as part of the Maze struct
-    Maze { width, height, tiles, graph, entrance, nexus_pos, node_map }
+    Maze {
+        width,
+        height,
+        tiles,
+        graph,
+        entrance,
+        nexus_pos,
+        node_map,
+    }
 }
 
 // A helper function to find a path through the maze.
@@ -388,10 +478,13 @@ fn find_path(
     );
 
     if let Some((_cost, path_indices)) = result {
-        let path_coords = path_indices.into_iter().map(|node_idx| {
-            let flat_index = maze.node_map.iter().position(|&n| n == node_idx).unwrap();
-            (flat_index % maze.width, flat_index / maze.width)
-        }).collect();
+        let path_coords = path_indices
+            .into_iter()
+            .map(|node_idx| {
+                let flat_index = maze.node_map.iter().position(|&n| n == node_idx).unwrap();
+                (flat_index % maze.width, flat_index / maze.width)
+            })
+            .collect();
         Some(path_coords)
     } else {
         None


### PR DESCRIPTION
## Summary
- add `tower_placement_system` registered during in-game updates
- spawn towers on walls when left mouse button is pressed at that tile

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6866cb808ff8832e906dfc09372ed987